### PR TITLE
feat(content): wiki routes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 <a className="btn" href="/verletzungen">Verletzungen</a>
                 <a className="btn" href="/hks">HKS</a>
                 <a className="btn" href="/physiologie">Physiologie</a>
+                <a className="btn" href="/wissen">Wissen</a>
                 <a className="btn" href="/tools">Tools</a>
                 <ThemeToggle />
               </nav>

--- a/app/wissen/[...slug]/page.tsx
+++ b/app/wissen/[...slug]/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getWikiArticle, getWikiSlugs, getWikiTitle } from "@/lib/wiki";
+
+type WikiPageProps = {
+  params: {
+    slug: string[];
+  };
+};
+
+export async function generateStaticParams() {
+  const slugs = await getWikiSlugs();
+  return slugs.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: WikiPageProps): Promise<Metadata> {
+  const title = await getWikiTitle(params.slug);
+  if (!title) {
+    return {
+      title: "Wissensartikel",
+    };
+  }
+
+  return {
+    title,
+  };
+}
+
+export default async function WikiArticlePage({ params }: WikiPageProps) {
+  const article = await getWikiArticle(params.slug);
+
+  if (!article) {
+    notFound();
+  }
+
+  return (
+    <article className="space-y-6">
+      <div className="space-y-2">
+        <Link className="text-sm text-blue-600 hover:underline dark:text-blue-400" href="/wissen">
+          ← Zurück zur Übersicht
+        </Link>
+        <h1 className="text-3xl font-semibold">{article.title}</h1>
+      </div>
+      <div
+        className="space-y-4 [&>p]:leading-relaxed [&>ul]:list-disc [&>ul]:space-y-2 [&>ul]:pl-6 [&>ul>li]:marker:text-blue-500"
+        dangerouslySetInnerHTML={{ __html: article.html }}
+      />
+    </article>
+  );
+}

--- a/app/wissen/page.tsx
+++ b/app/wissen/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getWikiList } from "@/lib/wiki";
+
+export const metadata: Metadata = {
+  title: "Wissen",
+  description: "Schneller Überblick über alle Markdown-Wissensartikel.",
+};
+
+export default async function WissenIndexPage() {
+  const articles = await getWikiList();
+
+  return (
+    <section className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">Wissen</h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          Alle verfügbaren Wissensartikel aus dem Markdown-Ordner.
+        </p>
+      </header>
+
+      {articles.length === 0 ? (
+        <p className="text-gray-600 dark:text-gray-400">
+          Noch keine Inhalte vorhanden.
+        </p>
+      ) : (
+        <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {articles.map((article) => (
+            <li key={article.slug.join("/")}>
+              <Link
+                className="card block p-4 transition hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                href={`/wissen/${article.slug.join("/")}`}
+              >
+                <span className="font-medium text-lg">{article.title}</span>
+                <span className="mt-2 flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400">
+                  Weiterlesen
+                  <span aria-hidden>→</span>
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/lib/wiki.ts
+++ b/lib/wiki.ts
@@ -1,0 +1,128 @@
+import fs from "fs/promises";
+import path from "path";
+import matter from "gray-matter";
+import { remark } from "remark";
+import remarkHtml from "remark-html";
+
+const CONTENT_ROOT = path.resolve("content");
+
+export interface WikiListItem {
+  slug: string[];
+  title: string;
+}
+
+export interface WikiArticle extends WikiListItem {
+  html: string;
+}
+
+function normalizeSlugSegment(segment: string): string {
+  return segment.replace(/\\.md$/i, "");
+}
+
+function resolveMarkdownPath(slug: string[]): string | null {
+  const sanitizedSegments = slug.map(normalizeSlugSegment);
+  const targetPath = path.join(CONTENT_ROOT, ...sanitizedSegments) + ".md";
+  const normalized = path.normalize(targetPath);
+  const relative = path.relative(CONTENT_ROOT, normalized);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return null;
+  }
+  return normalized;
+}
+
+async function collectMarkdownFiles(directory: string, prefix: string[] = []): Promise<{
+  slug: string[];
+  filePath: string;
+}[]> {
+  const dirents = await fs.readdir(directory, { withFileTypes: true });
+  const entries: { slug: string[]; filePath: string }[] = [];
+
+  for (const dirent of dirents) {
+    if (dirent.isDirectory()) {
+      const nested = await collectMarkdownFiles(path.join(directory, dirent.name), [
+        ...prefix,
+        dirent.name,
+      ]);
+      entries.push(...nested);
+    } else if (dirent.isFile() && dirent.name.endsWith(".md")) {
+      const baseName = dirent.name.slice(0, -3);
+      entries.push({
+        slug: [...prefix, baseName],
+        filePath: path.join(directory, dirent.name),
+      });
+    }
+  }
+
+  return entries;
+}
+
+function extractTitle(data: Record<string, unknown>, slug: string[]): string {
+  const rawTitle = data.title;
+  if (typeof rawTitle === "string" && rawTitle.trim().length > 0) {
+    return rawTitle.trim();
+  }
+  const fallback = slug[slug.length - 1] ?? "Unbenannt";
+  return fallback.replace(/[-_]/g, " ");
+}
+
+export async function getWikiList(): Promise<WikiListItem[]> {
+  const entries = await collectMarkdownFiles(CONTENT_ROOT);
+  const items: WikiListItem[] = [];
+
+  for (const entry of entries) {
+    const fileContent = await fs.readFile(entry.filePath, "utf8");
+    const parsed = matter(fileContent);
+    items.push({
+      slug: entry.slug,
+      title: extractTitle(parsed.data as Record<string, unknown>, entry.slug),
+    });
+  }
+
+  return items.sort((a, b) => a.title.localeCompare(b.title, "de"));
+}
+
+export async function getWikiSlugs(): Promise<string[][]> {
+  const entries = await collectMarkdownFiles(CONTENT_ROOT);
+  return entries.map((entry) => entry.slug);
+}
+
+export async function getWikiArticle(slug: string[]): Promise<WikiArticle | null> {
+  const filePath = resolveMarkdownPath(slug);
+  if (!filePath) {
+    return null;
+  }
+
+  let fileContent: string;
+  try {
+    fileContent = await fs.readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+
+  const parsed = matter(fileContent);
+  const processed = await remark().use(remarkHtml).process(parsed.content);
+
+  const sanitizedSlug = slug.map(normalizeSlugSegment);
+
+  return {
+    slug: sanitizedSlug,
+    title: extractTitle(parsed.data as Record<string, unknown>, sanitizedSlug),
+    html: processed.toString(),
+  };
+}
+
+export async function getWikiTitle(slug: string[]): Promise<string | null> {
+  const filePath = resolveMarkdownPath(slug);
+  if (!filePath) {
+    return null;
+  }
+
+  try {
+    const fileContent = await fs.readFile(filePath, "utf8");
+    const parsed = matter(fileContent);
+    const sanitizedSlug = slug.map(normalizeSlugSegment);
+    return extractTitle(parsed.data as Record<string, unknown>, sanitizedSlug);
+  } catch {
+    return null;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,13 @@
       "dependencies": {
         "framer-motion": "^11.3.31",
         "fuse.js": "file:vendor/fuse.js",
+        "gray-matter": "file:vendor/gray-matter",
         "lucide-react": "^0.452.0",
         "next": "14.2.5",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "remark": "file:vendor/remark",
+        "remark-html": "file:vendor/remark-html",
         "zod": "file:vendor/zod"
       },
       "devDependencies": {
@@ -865,6 +868,10 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/gray-matter": {
+      "resolved": "vendor/gray-matter",
+      "link": true
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1520,6 +1527,14 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/remark": {
+      "resolved": "vendor/remark",
+      "link": true
+    },
+    "node_modules/remark-html": {
+      "resolved": "vendor/remark-html",
+      "link": true
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -2118,6 +2133,15 @@
     "vendor/fuse.js": {
       "version": "6.6.2",
       "license": "MIT"
+    },
+    "vendor/gray-matter": {
+      "version": "0.0.0"
+    },
+    "vendor/remark": {
+      "version": "0.0.0"
+    },
+    "vendor/remark-html": {
+      "version": "0.0.0"
     },
     "vendor/zod": {
       "version": "0.0.0-local",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,13 @@
   "dependencies": {
     "framer-motion": "^11.3.31",
     "fuse.js": "file:vendor/fuse.js",
+    "gray-matter": "file:vendor/gray-matter",
     "lucide-react": "^0.452.0",
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "remark": "file:vendor/remark",
+    "remark-html": "file:vendor/remark-html",
     "zod": "file:vendor/zod"
   },
   "devDependencies": {

--- a/stubs/@types/node/index.d.ts
+++ b/stubs/@types/node/index.d.ts
@@ -16,10 +16,19 @@ declare global {
 declare module "path" {
   export function join(...segments: string[]): string;
   export function relative(from: string, to: string): string;
+  export function resolve(...segments: string[]): string;
+  export function normalize(path: string): string;
+  export function isAbsolute(path: string): boolean;
 }
 
 declare module "fs/promises" {
+  export interface Dirent {
+    name: string;
+    isDirectory(): boolean;
+    isFile(): boolean;
+  }
   export function readFile(path: string, options: { encoding: string } | string): Promise<string>;
+  export function readdir(path: string, options: { withFileTypes: true }): Promise<Dirent[]>;
 }
 
 declare module "process" {

--- a/vendor/gray-matter/index.d.ts
+++ b/vendor/gray-matter/index.d.ts
@@ -1,0 +1,11 @@
+declare namespace matter {
+  interface GrayMatterFile {
+    content: string;
+    data: Record<string, unknown>;
+    matter: string;
+  }
+}
+
+declare function matter(input: string): matter.GrayMatterFile;
+
+export = matter;

--- a/vendor/gray-matter/index.js
+++ b/vendor/gray-matter/index.js
@@ -1,0 +1,158 @@
+function splitTopLevel(input, delimiter) {
+  const result = [];
+  let current = "";
+  let depth = 0;
+  let quoteChar = null;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+    if (quoteChar) {
+      current += char;
+      if (char === quoteChar && input[i - 1] !== "\\") {
+        quoteChar = null;
+      }
+      continue;
+    }
+
+    if (char === "\"" || char === "'") {
+      quoteChar = char;
+      current += char;
+      continue;
+    }
+
+    if (char === "{" || char === "[") {
+      depth += 1;
+      current += char;
+      continue;
+    }
+
+    if (char === "}" || char === "]") {
+      if (depth > 0) {
+        depth -= 1;
+      }
+      current += char;
+      continue;
+    }
+
+    if (depth === 0 && char === delimiter) {
+      if (current.trim().length > 0) {
+        result.push(current.trim());
+      }
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  const finalValue = current.trim();
+  if (finalValue.length > 0) {
+    result.push(finalValue);
+  }
+
+  return result;
+}
+
+function stripQuotes(value) {
+  if (
+    (value.startsWith("\"") && value.endsWith("\"")) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function parseValue(raw) {
+  const value = raw.trim();
+  if (!value) {
+    return "";
+  }
+
+  if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+
+  if (value === "true" || value === "false") {
+    return value === "true";
+  }
+
+  if (!Number.isNaN(Number(value)) && value === String(Number(value))) {
+    return Number(value);
+  }
+
+  if (value.startsWith("[") && value.endsWith("]")) {
+    const inner = value.slice(1, -1).trim();
+    if (!inner) {
+      return [];
+    }
+    return splitTopLevel(inner, ",").map((part) => parseValue(part));
+  }
+
+  if (value.startsWith("{") && value.endsWith("}")) {
+    const inner = value.slice(1, -1).trim();
+    if (!inner) {
+      return {};
+    }
+    const entries = splitTopLevel(inner, ",");
+    const result = {};
+    for (const entry of entries) {
+      const separator = entry.indexOf(":");
+      if (separator === -1) {
+        continue;
+      }
+      const key = stripQuotes(entry.slice(0, separator).trim());
+      const entryValue = entry.slice(separator + 1).trim();
+      result[key] = parseValue(entryValue);
+    }
+    return result;
+  }
+
+  return stripQuotes(value);
+}
+
+function parseFrontMatterBlock(block) {
+  const data = {};
+  const lines = block.split(/\r?\n/);
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    const separator = line.indexOf(":");
+    if (separator === -1) {
+      continue;
+    }
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1);
+    if (!key) {
+      continue;
+    }
+    data[key] = parseValue(value);
+  }
+  return data;
+}
+
+function matter(input) {
+  const source = input == null ? "" : String(input);
+  const frontMatterMatch = source.match(/^---\s*\r?\n([\s\S]*?)\r?\n---\s*\r?\n?/);
+
+  if (!frontMatterMatch) {
+    return {
+      content: source,
+      data: {},
+      matter: "",
+    };
+  }
+
+  const [, frontMatter] = frontMatterMatch;
+  const content = source.slice(frontMatterMatch[0].length);
+  return {
+    content,
+    data: parseFrontMatterBlock(frontMatter),
+    matter: frontMatterMatch[0],
+  };
+}
+
+module.exports = matter;
+matter.default = matter;
+matter.matter = matter;

--- a/vendor/gray-matter/package.json
+++ b/vendor/gray-matter/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "gray-matter",
+  "version": "0.0.0",
+  "main": "index.js",
+  "types": "index.d.ts"
+}

--- a/vendor/remark-html/index.d.ts
+++ b/vendor/remark-html/index.d.ts
@@ -1,0 +1,3 @@
+export type RemarkHtmlTransformer = (markdown: string) => string | Promise<string>;
+
+export default function remarkHtml(): RemarkHtmlTransformer;

--- a/vendor/remark-html/index.js
+++ b/vendor/remark-html/index.js
@@ -1,0 +1,79 @@
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function convertInline(text) {
+  const escaped = escapeHtml(text);
+  return escaped
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>");
+}
+
+function markdownToHtml(markdown) {
+  const lines = String(markdown ?? "")
+    .replace(/\r\n/g, "\n")
+    .split(/\n/);
+
+  const htmlParts = [];
+  let inList = false;
+  let paragraphBuffer = [];
+
+  const closeList = () => {
+    if (inList) {
+      htmlParts.push("</ul>");
+      inList = false;
+    }
+  };
+
+  const flushParagraph = () => {
+    if (paragraphBuffer.length === 0) {
+      return;
+    }
+    const text = paragraphBuffer.join(" ");
+    htmlParts.push(`<p>${convertInline(text)}</p>`);
+    paragraphBuffer = [];
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (!line.trim()) {
+      closeList();
+      flushParagraph();
+      continue;
+    }
+
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      closeList();
+      flushParagraph();
+      htmlParts.push(`<h${level}>${convertInline(headingMatch[2])}</h${level}>`);
+      continue;
+    }
+
+    const listMatch = line.match(/^[-*+]\s+(.*)$/);
+    if (listMatch) {
+      flushParagraph();
+      if (!inList) {
+        htmlParts.push("<ul>");
+        inList = true;
+      }
+      htmlParts.push(`<li>${convertInline(listMatch[1])}</li>`);
+      continue;
+    }
+
+    paragraphBuffer.push(line.trim());
+  }
+
+  closeList();
+  flushParagraph();
+
+  return htmlParts.join("");
+}
+
+module.exports = function remarkHtml() {
+  return async (markdown) => markdownToHtml(markdown);
+};

--- a/vendor/remark-html/package.json
+++ b/vendor/remark-html/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "remark-html",
+  "version": "0.0.0",
+  "main": "index.js",
+  "types": "index.d.ts"
+}

--- a/vendor/remark/index.d.ts
+++ b/vendor/remark/index.d.ts
@@ -1,0 +1,14 @@
+export interface ProcessResult {
+  value: string;
+  toString(): string;
+}
+
+export interface Processor {
+  use(
+    plugin: (options?: any) => ((input: string) => string | Promise<string>) | void,
+    options?: any
+  ): Processor;
+  process(markdown: string): Promise<ProcessResult>;
+}
+
+export function remark(): Processor;

--- a/vendor/remark/index.js
+++ b/vendor/remark/index.js
@@ -1,0 +1,35 @@
+class Processor {
+  constructor() {
+    this.plugins = [];
+  }
+
+  use(plugin, options) {
+    if (typeof plugin === "function") {
+      const transformer = plugin(options);
+      if (typeof transformer === "function") {
+        this.plugins.push(transformer);
+      }
+    }
+    return this;
+  }
+
+  async process(markdown) {
+    let result = String(markdown ?? "");
+    for (const transformer of this.plugins) {
+      // eslint-disable-next-line no-await-in-loop
+      result = await transformer(result);
+    }
+    return {
+      value: result,
+      toString() {
+        return result;
+      },
+    };
+  }
+}
+
+function remark() {
+  return new Processor();
+}
+
+module.exports = { remark };

--- a/vendor/remark/package.json
+++ b/vendor/remark/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "remark",
+  "version": "0.0.0",
+  "main": "index.js",
+  "types": "index.d.ts"
+}


### PR DESCRIPTION
## Summary
- add a Wissen index page that lists Markdown stubs with their frontmatter titles
- implement a catch-all Wissen article route that parses frontmatter and renders Markdown to HTML
- add helper utilities and vendored markdown/frontmatter parsers plus a navbar link to the Wissen section

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c891d4d5e883219be8545e88512ce5